### PR TITLE
requested changes on filter and layout

### DIFF
--- a/client/src/pages/logs-screen/LogTable.tsx
+++ b/client/src/pages/logs-screen/LogTable.tsx
@@ -172,7 +172,6 @@ const LogTable: React.FC<LogTableProps> = ({
                   <Td fontWeight="bold">{item.created_at}</Td>
                   <Td>
                     <Text>
-                      {" "}
                       {item.meta
                         ? item.meta.split(" ").slice(0, 6).join(" ") +
                           (item.meta.split(" ").length > 6 ? " ..." : "")

--- a/client/src/pages/logs-screen/LogTable.tsx
+++ b/client/src/pages/logs-screen/LogTable.tsx
@@ -76,7 +76,7 @@ const LogTable: React.FC<LogTableProps> = ({
       : {}),
   };
   const { data, isLoading } = useLogsList(filter);
-  const itemsPerPage = 2;
+  const itemsPerPage = 5;
   const [currentPage, setCurrentPage] = useState(0);
   const handlePageChange = (newPage: number) => {
     setCurrentPage(newPage);
@@ -171,7 +171,13 @@ const LogTable: React.FC<LogTableProps> = ({
 
                   <Td fontWeight="bold">{item.created_at}</Td>
                   <Td>
-                    <Text>{item.meta ? item.meta : "N/A"}</Text>
+                    <Text>
+                      {" "}
+                      {item.meta
+                        ? item.meta.split(" ").slice(0, 6).join(" ") +
+                          (item.meta.split(" ").length > 6 ? " ..." : "")
+                        : "N/A"}
+                    </Text>
                   </Td>
                 </Tr>
               ))

--- a/client/src/pages/logs-screen/Logs.tsx
+++ b/client/src/pages/logs-screen/Logs.tsx
@@ -30,6 +30,7 @@ const Logs = () => {
   const filter = { ...projectIdFilter };
   const { data: projectList, isLoading: projectListLoading } =
     useProjectList(filter);
+  const { data: allProjectList } = useProjectList({});
 
   const handleLogTypeChange = (event: any) => {
     setSelectedLogType(event.target.value);
@@ -47,10 +48,11 @@ const Logs = () => {
   if (projectListLoading) {
     return <Text>Loading...</Text>;
   }
+
   return (
     <>
       <TopBar />
-      <Box maxW="65.25rem" mx="auto" mt="7.75rem">
+      <Box maxW="80%" mx="auto" mt="3.75rem">
         <Heading as="h1">Logs</Heading>
 
         <Flex
@@ -59,7 +61,7 @@ const Logs = () => {
           alignItems="center"
           bg="white"
           justifyContent="space-between"
-          mt="4rem"
+          mt="1rem"
           mb="1.25rem"
         >
           <Flex>
@@ -67,17 +69,16 @@ const Logs = () => {
               <Icon as={AiOutlineFolder} boxSize={6} mr={2} />
               <Select
                 placeholder={
-                  projectId ? projectList?.projectCode : "All Projects"
+                  projectId ? projectList[0].projectCode : "All Projects"
                 }
                 value={selectedProject}
                 onChange={handleProjectTypeChange}
               >
-                {projectList &&
-                  projectList.map((project: any) => (
-                    <option key={project.projectId} value={project.projectId}>
-                      {project.projectCode}
-                    </option>
-                  ))}
+                {allProjectList.map((project: any) => (
+                  <option key={project.projectId} value={project.projectId}>
+                    {project.projectCode}
+                  </option>
+                ))}
               </Select>
               <Box borderLeft="1px solid black" height="1.875" mx={2} />
             </HStack>

--- a/client/src/pages/logs-screen/Logs.tsx
+++ b/client/src/pages/logs-screen/Logs.tsx
@@ -98,7 +98,7 @@ const Logs = () => {
             <HStack align="center">
               <Icon as={AiOutlineCalendar} boxSize={6} mr={2} />
               <Select
-                placeholder="Time"
+                placeholder="All Time"
                 value={selectedTime}
                 onChange={handleTimeChange}
               >

--- a/client/src/pages/projects/ProjectsList.tsx
+++ b/client/src/pages/projects/ProjectsList.tsx
@@ -51,7 +51,7 @@ const ProjectsList = () => {
   return (
     <>
       <TopBar />
-      <Box maxW="65.25rem" mx="auto" mt="7.75rem">
+      <Box maxW="80%" mx="auto" mt="7.75rem">
         <Heading as="h1" color="#746666">
           Project List
         </Heading>

--- a/client/src/routes/AuthenticatedRoutes.tsx
+++ b/client/src/routes/AuthenticatedRoutes.tsx
@@ -2,7 +2,6 @@ import { Route, Routes } from "react-router-dom";
 import Logs from "../pages/logs-screen/Logs";
 import ProjectsList from "../pages/projects/ProjectsList";
 import LogDetails from "../pages/logs-screen/LogDetails";
-import LogTable from "../pages/logs-screen/LogTable";
 
 const AuthenticatedRoutes = () => {
   return (


### PR DESCRIPTION
-->When Clicked on the project it redirects to the logs of the selected project and in project list filter we can see other projects and we can filter out..
--->Trimmed the length of meta data
-->Small Change in layout (width and height)
-->5 logs per page 
![l1](https://github.com/odesseyHQ/nibbles-logtrack/assets/132039951/75fed082-5748-496d-9f8b-3bb5d40c7d35)
![l2](https://github.com/odesseyHQ/nibbles-logtrack/assets/132039951/affedcdb-0d26-4bc8-8a7e-5c2b59c4aa81)
